### PR TITLE
Add Helper Method in DataParser to Read Option Chain Data

### DIFF
--- a/backtest/backtest_base.py
+++ b/backtest/backtest_base.py
@@ -78,7 +78,6 @@ class BacktestBase(object):
         if InstrumentType.STOCK.value in instruments:
             self.option_data = self._load_stock_data(instruments[InstrumentType.STOCK.value])
 
-
     def _load_stock_data(self, symbols: List[str]) -> Dict[str, OHLCV]:
         """
         Initialize OHLCV objects for each symbol. Data ts is in UTC timezone.
@@ -103,8 +102,8 @@ class BacktestBase(object):
         """
         option_data = {}
         for symbol in symbols:
-            path = f"{self.history_data_path}/{symbol}/option-day.csv"
-            df = pd.read_csv(path)
+            path = f"{self.history_data_path}/{symbol}"
+            df = DataParser.read_option_chain(path)
             option_data[symbol] = OptionChain(df)
 
         return option_data

--- a/backtest/data_parser/data_parser.py
+++ b/backtest/data_parser/data_parser.py
@@ -4,11 +4,9 @@ Author: Zhicheng Tang
 Created Date: 8/24/24
 Description: <This class parses the raw data into the format that strategy and backtest could use.>
 """
-from multiprocessing import process
 from typing import List
 import pandas as pd
 import os
-import glob
 
 from ..utils.constant import FREQUENCY
 
@@ -112,11 +110,14 @@ class DataParser(object):
         return results
 
     @staticmethod
-    def read_option_chain(data_path: str, underlying_symbol: str) -> pd.DataFrame:
+    def process_option_chain(data_path: str, underlying_symbol: str) -> pd.DataFrame:
         """
         Reads all option chain CSVs for a specific symbol from a directory,
         merge and reformats them to a CBOE-like option EOD summary schema.
         https://datashop.cboe.com/option-eod-summary
+
+        This function is not used by any backtest class. It is used manually to process the raw option
+        chain data which is not in CBOE format. It only needs to be used once.
         """
         print(f"Starting to parse option data for {underlying_symbol} from {data_path}")
 
@@ -197,3 +198,10 @@ class DataParser(object):
         final_df = pd.concat(processed_dfs, ignore_index=True)
         final_df.sort_values(by=['quote_date', 'expiration', 'strike'], inplace=True)
         return final_df
+
+    @staticmethod
+    def read_option_chain(path: str) -> pd.DataFrame:
+        """
+        Currently, do not expect to read higher frequency option data in the near future.
+        """
+        return pd.read_csv(f"{path}/option-day.csv")

--- a/backtest/data_parser/option_chain.py
+++ b/backtest/data_parser/option_chain.py
@@ -5,11 +5,15 @@ Created Date: 08/12/25
 Description: a wrapper for an option chain dataframe, providing convenient query methods.
 """
 import pandas as pd
+from typing import Dict, List, Tuple, Optional
 
 
 class OptionChain:
     def __init__(self, data: pd.DataFrame):
         data["quote_date"] = pd.to_datetime(data["quote_date"])
+        data["expiration"] = pd.to_datetime(data["expiration"])
+        data["DTE"] = (data["expiration"] - data["quote_date"]).dt.days
+
         self.data = data
         self.underlying_symbol = self.data.iloc[0]["underlying_symbol"]
 


### PR DESCRIPTION
### PR Summary

**Description:**
<!-- Provide a concise summary of what this PR does, including the motivation behind it. -->

Rename previous read_option_chain method to process_option_chain. It formats the raw option data into CBOE format.

Add another read_option_chain method to read processed option data into df. Currently, it assumes the frequency is daily.

**Issue(s) Fixed:**
<!-- List any issues this PR addresses, using the format "Fixes #issue_number". If there are no related issues, state "None". -->

### Checklist

- [ ] Manually tested changes
- [ ] Automated tests added/updated
- [ ] Reviewed changes
- [ ] Documentation updated (if applicable)

### Additional Notes
<!-- Add any additional notes or comments that might be helpful for the reviewer. -->
